### PR TITLE
fix: prevent fatal error when post has no collection terms

### DIFF
--- a/also-in-this-collection-core.php
+++ b/also-in-this-collection-core.php
@@ -99,10 +99,14 @@ function displayCollection($args = []) {
     $currentpostid = $post ? $post->ID : null;
 
     // Get collection term
+    $collection = null;
     if ($collectionslug) {
         $collection = get_term_by('slug', $collectionslug, COLLECTION_TAXONOMY);
-    } else {
-        $post && $postcollection = get_the_terms($post->ID, COLLECTION_TAXONOMY) && $collection = reset($postcollection);
+    } else if ($post) {
+        $postcollection = get_the_terms($post->ID, COLLECTION_TAXONOMY);
+        if ($postcollection && is_array($postcollection) && !is_wp_error($postcollection)) {
+            $collection = reset($postcollection);
+        }
     }
 
     if (!$collection) {


### PR DESCRIPTION
- Replace chained && operators with proper conditional checks
- Add null and type validation before calling reset() on get_the_terms() result
- Initialize $collection variable to prevent undefined variable warnings
- Fixes TypeError: reset(): Argument #1 must be of type array, null given

The get_the_terms() function can return false, null, or WP_Error when no terms are found, but the original code assumed it would always return an array.